### PR TITLE
fix: UAA delete user endpoint returns false error during upgrade canary deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ List of relations
  public | groups                        | table    | root
  public | identity_provider             | table    | root
  public | identity_zone                 | table    | root
+ public | mfa_providers                 | table    | root
  public | oauth_client_details          | table    | root
  public | oauth_code                    | table    | root
  public | oauth_code_id_seq             | sequence | root
@@ -196,6 +197,7 @@ List of relations
  public | sec_audit_id_seq              | sequence | root
  public | spring_session                | table    | root
  public | spring_session_attributes     | table    | root
+ public | user_google_mfa_credentials   | table    | root
  public | user_info                     | table    | root
  public | users                         | table    | root
 (23 rows)

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_108__Restore_MFA_Tables.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_108__Restore_MFA_Tables.sql
@@ -1,0 +1,28 @@
+--
+-- These tables were previously dropped in https://github.com/cloudfoundry/uaa/pull/2717
+-- Restoring them here due to https://github.com/cloudfoundry/uaa/issues/2789
+-- Can consider dropping these again in the future (e.g. at UAA V78/79, when most users
+-- will no longer experience issue #2789)
+--
+
+CREATE TABLE mfa_providers (
+  id CHAR(36) NOT NULL PRIMARY KEY,
+  created TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  lastmodified TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  identity_zone_id varchar(36) NOT NULL,
+  name varchar(255) NOT NULL,
+  type varchar(255) NOT NULL,
+  config LONGVARCHAR
+);
+
+CREATE TABLE user_google_mfa_credentials (
+  user_id VARCHAR(36) NOT NULL,
+  secret_key VARCHAR(255) NOT NULL,
+  validation_code INTEGER,
+  scratch_codes VARCHAR(255) NOT NULL,
+  mfa_provider_id CHAR(36) NOT NULL,
+  zone_id CHAR(36) NOT NULL,
+  encryption_key_label VARCHAR(255),
+  encrypted_validation_code VARCHAR(255) NULL,
+  PRIMARY KEY (user_id,mfa_provider_id)
+);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_108__Restore_MFA_Tables.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_108__Restore_MFA_Tables.sql
@@ -1,0 +1,27 @@
+--
+-- These tables were previously dropped in https://github.com/cloudfoundry/uaa/pull/2717
+-- Restoring them here due to https://github.com/cloudfoundry/uaa/issues/2789
+-- Can consider dropping these again in the future (e.g. at UAA V78/79, when most users
+-- will no longer experience issue #2789)
+--
+
+CREATE TABLE IF NOT EXISTS `mfa_providers` (
+  `id` varchar(36) NOT NULL,
+  `created` TIMESTAMP default current_timestamp NOT NULL,
+  `lastModified` TIMESTAMP null,
+  `identity_zone_id` varchar(36) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `type` varchar(255) NOT NULL,
+  `config` longtext
+);
+
+CREATE TABLE IF NOT EXISTS `user_google_mfa_credentials` (
+  `user_id` VARCHAR(36) NOT NULL,
+  `secret_key` VARCHAR(255) NOT NULL,
+  `validation_code` INTEGER NULL,
+  `scratch_codes` VARCHAR(255) NOT NULL,
+  `mfa_provider_id` CHAR(36) NOT NULL,
+  `zone_id` CHAR(36) NOT NULL,
+  `encryption_key_label` VARCHAR(255),
+  `encrypted_validation_code` VARCHAR(255) NULL
+);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_108__Restore_MFA_Tables.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_108__Restore_MFA_Tables.sql
@@ -1,0 +1,29 @@
+--
+-- These tables were previously dropped in https://github.com/cloudfoundry/uaa/pull/2717
+-- Restoring them here due to https://github.com/cloudfoundry/uaa/issues/2789
+--
+-- Can consider dropping these again in the future (e.g. at UAA V78/79, when most users
+-- will no longer experience issue #2789)
+--
+
+CREATE TABLE IF NOT EXISTS mfa_providers (
+  id VARCHAR(36) NOT NULL PRIMARY KEY,
+  created TIMESTAMP default current_timestamp NOT NULL,
+  lastModified TIMESTAMP null,
+  identity_zone_id VARCHAR(36) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  type VARCHAR(255) NOT NULL,
+  config TEXT
+);
+
+CREATE TABLE IF NOT EXISTS user_google_mfa_credentials (
+  user_id VARCHAR(36) NOT NULL PRIMARY KEY,
+  secret_key VARCHAR(255) NOT NULL,
+  validation_code INTEGER,
+  scratch_codes VARCHAR(255) NOT NULL,
+  mfa_provider_id CHAR(36) NOT NULL,
+  zone_id CHAR(36) NOT NULL,
+  encryption_key_label VARCHAR(255),
+  encrypted_validation_code VARCHAR(255) NULL
+);
+


### PR DESCRIPTION
pr_rerun pr/develop/fix-canary-deploy-user-delete to develop